### PR TITLE
Add options page for API endpoint and token

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,8 +9,10 @@
     "128": "icons/icon-128.png"
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
+  "options_page": "options.html",
   "content_scripts": [
     {
       "matches": [

--- a/options.html
+++ b/options.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Options</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .container { width: 400px; }
+    label { display: block; margin-bottom: 5px; }
+    input[type="text"], input[type="password"] {
+      width: 100%;
+      padding: 8px;
+      margin-bottom: 10px;
+      border: 1px solid #ccc;
+      box-sizing: border-box;
+    }
+    button {
+      background-color: #4CAF50;
+      color: white;
+      padding: 10px 15px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    button:hover {
+      background-color: #45a049;
+    }
+    #status { margin-top: 10px; color: green; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Options</h1>
+    <div>
+      <label for="apiEndpoint">API Endpoint (URL):</label>
+      <input type="text" id="apiEndpoint">
+    </div>
+    <div>
+      <label for="apiToken">API Token:</label>
+      <input type="password" id="apiToken">
+    </div>
+    <button id="save">Save</button>
+    <div id="status"></div>
+  </div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,31 @@
+// Saves options to chrome.storage
+function save_options() {
+  var apiEndpoint = document.getElementById('apiEndpoint').value;
+  var apiToken = document.getElementById('apiToken').value;
+  chrome.storage.sync.set({
+    apiEndpoint: apiEndpoint,
+    apiToken: apiToken
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  chrome.storage.sync.get({
+    apiEndpoint: '',
+    apiToken: ''
+  }, function(items) {
+    document.getElementById('apiEndpoint').value = items.apiEndpoint;
+    document.getElementById('apiToken').value = items.apiToken;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);


### PR DESCRIPTION
This commit introduces an options page for the Chrome extension.

- Adds `options.html` with a form for API endpoint and token.
- Adds `options.js` to handle saving and loading these settings using `chrome.storage.sync`.
- Updates `manifest.json` to declare the options page and add the `storage` permission.